### PR TITLE
Selective populates for deffer.populate

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -225,6 +225,16 @@ Deferred.prototype.populate = function(keyName, criteria) {
       select.push(obj.columnName);
     });
 
+    if (Array.isArray(criteria.select)) {
+      if (criteria.select.indexOf(join.parentKey) < 0) {
+        criteria.select.unshift(join.parentKey);
+      }
+
+      select = select.filter(function (item) {
+        return criteria.select.indexOf(item) >= 0;
+      });
+    }
+
     join.select = select;
 
     // If linking to a junction table the attributes shouldn't be included in the return value
@@ -522,7 +532,6 @@ Deferred.prototype.exec = function(cb) {
   var args = Array.prototype.slice.call(arguments);
   if(this._values) args.unshift(this._values);
   args.unshift(this._criteria);
-
   // Pass control to the adapter with the appropriate arguments.
   this._method.apply(this._context, args);
 };

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -89,7 +89,7 @@ Deferred.prototype.populateSome = function (associations) {
   _.isArray(associations) && (associations = _.zipObject(associations));
 
   _.isPlainObject(associations) && Object.keys(associations).forEach(function (assoc) {
-    self.populate(assoc, _.isPlainObject(associations[assoc]) ? associations[assoc] : {});
+    self.populate(assoc, associations[assoc]);
   });
 
   return self;

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -282,7 +282,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
         // Build out the second join object that will link a junction table with the
         // values being populated
-        var selects = _.map(_.keys(this._context.waterline.schema[reference[ref].references].attributes), function(attr) {
+        var selects = userSelect || _.map(_.keys(this._context.waterline.schema[reference[ref].references].attributes), function(attr) {
           var expandedAttr = self._context.waterline.schema[reference[ref].references].attributes[attr];
           return expandedAttr.columnName || attr;
         });
@@ -295,6 +295,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
           select: selects,
           alias: keyName,
           junctionTable: true,
+          reducedSelection: !!userSelect,
           removeParentKey: parentKey.model ? true : false,
           model: false,
           collection: true

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -79,15 +79,20 @@ Deferred.prototype.populateDeep = function ( keyName, criteria ) {
  *     where: { name: 'hello' }
  *   }
  * });
+ * // or
+ * .populateSome(['model1', 'model2']);
  */
-Deferred.prototype.populateSome = function(associations) {
+Deferred.prototype.populateSome = function (associations) {
   var self = this;
 
-  associations && Object.keys(associations).forEach(function (assoc) {
+  // an array of strings is converted to an object
+  _.isArray(associations) && (associations = _.zipObject(associations));
+
+  _.isPlainObject(associations) && Object.keys(associations).forEach(function (assoc) {
     self.populate(assoc, _.isPlainObject(associations[assoc]) ? associations[assoc] : {});
   });
 
-  return this;
+  return self;
 };
 
 /**

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -66,6 +66,31 @@ Deferred.prototype.populateDeep = function ( keyName, criteria ) {
 };
 
 /**
+ * Populate some associations of a collection.
+ *
+ * @param {object} associations
+ * @return this
+ * @chainable
+ *
+ * @example
+ * .populateSome({
+ *   model1: true,
+ *   model2: {
+ *     where: { name: 'hello' }
+ *   }
+ * });
+ */
+Deferred.prototype.populateSome = function(associations) {
+  var self = this;
+
+  associations && Object.keys(associations).forEach(function (assoc) {
+    self.populate(assoc, _.isPlainObject(associations[assoc]) ? associations[assoc] : {});
+  });
+
+  return this;
+};
+
+/**
  * Populate all associations of a collection.
  *
  * @return this

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -88,8 +88,8 @@ Deferred.prototype.populateSome = function (associations) {
   // an array of strings is converted to an object
   _.isArray(associations) && (associations = _.zipObject(associations));
 
-  _.isPlainObject(associations) && Object.keys(associations).forEach(function (assoc) {
-    self.populate(assoc, associations[assoc]);
+  _.isPlainObject(associations) && Object.keys(associations).forEach(function (key) {
+    self.populate(key, associations[key]);
   });
 
   return self;
@@ -205,7 +205,6 @@ Deferred.prototype.populate = function(keyName, criteria) {
     // in case of user selection, must add primary key
     if(userSelect) {
       pk && (userSelect.indexOf(pk) < 0) && userSelect.unshift(pk);
-      (userSelect.indexOf(fKey) < 0) && userSelect.push(fKey);
     }
 
     userSelect && (criteria.select = userSelect);
@@ -223,6 +222,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       child: attr.references,
       childKey: attr.on,
       select: userSelect || Object.keys(this._context.waterline.schema[attr.references].attributes),
+      reducedSelection: !!userSelect,
       alias: keyName,
       removeParentKey: parentKey.model ? true : false,
       model: hasOwnProperty(parentKey, 'model') ? true : false,

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -127,6 +127,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
   var pk = 'id';
   var attr;
   var join;
+  var userSelect;
 
 
   // Normalize sub-criteria
@@ -197,7 +198,17 @@ Deferred.prototype.populate = function(keyName, criteria) {
     //   }
     // }, optionalCriteria )
     ////////////////////////////////////////////////////////////////////
+    var fKey = this._context.identity;
 
+    criteria.select && criteria.select.length && (userSelect = _.isArray(criteria.select) ?
+      [].concat(criteria.select) : [criteria.select]) ;
+    // in case of user selection, must add primary key
+    if(userSelect) {
+      pk && (userSelect.indexOf(pk) < 0) && userSelect.unshift(pk);
+      (userSelect.indexOf(fKey) < 0) && userSelect.push(fKey);
+    }
+
+    userSelect && (criteria.select = userSelect);
 
     // Grab the key being populated to check if it is a has many to belongs to
     // If it's a belongs_to the adapter needs to know that it should replace the foreign key
@@ -211,7 +222,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       parentKey: attr.columnName || pk,
       child: attr.references,
       childKey: attr.on,
-      select: Object.keys(this._context.waterline.schema[attr.references].attributes),
+      select: userSelect || Object.keys(this._context.waterline.schema[attr.references].attributes),
       alias: keyName,
       removeParentKey: parentKey.model ? true : false,
       model: hasOwnProperty(parentKey, 'model') ? true : false,
@@ -220,7 +231,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
     // Build select object to use in the integrator
     var select = [];
-    Object.keys(this._context.waterline.schema[attr.references].attributes).forEach(function(key) {
+    !userSelect && Object.keys(this._context.waterline.schema[attr.references].attributes).forEach(function(key) {
       var obj = self._context.waterline.schema[attr.references].attributes[key];
       if(!hasOwnProperty(obj, 'columnName')) {
         select.push(key);
@@ -230,7 +241,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       select.push(obj.columnName);
     });
 
-    join.select = select;
+    join.select = userSelect || select;
 
     // If linking to a junction table the attributes shouldn't be included in the return value
     if(this._context.waterline.schema[attr.references].junctionTable) join.select = false;

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -230,16 +230,6 @@ Deferred.prototype.populate = function(keyName, criteria) {
       select.push(obj.columnName);
     });
 
-    if (Array.isArray(criteria.select)) {
-      if (criteria.select.indexOf(join.parentKey) < 0) {
-        criteria.select.unshift(join.parentKey);
-      }
-
-      select = select.filter(function (item) {
-        return criteria.select.indexOf(item) >= 0;
-      });
-    }
-
     join.select = select;
 
     // If linking to a junction table the attributes shouldn't be included in the return value
@@ -537,6 +527,7 @@ Deferred.prototype.exec = function(cb) {
   var args = Array.prototype.slice.call(arguments);
   if(this._values) args.unshift(this._values);
   args.unshift(this._criteria);
+
   // Pass control to the adapter with the appropriate arguments.
   this._method.apply(this._context, args);
 };


### PR DESCRIPTION
- adds a `.populateSome` function to populate multiple associations in one call (convenience method)
- tweaks .populateSome to receive `select` as part of criteria
