### PR TITLE
Feature/update diff api

### DIFF
--- a/lib/waterline/adapter/dql.js
+++ b/lib/waterline/adapter/dql.js
@@ -238,12 +238,12 @@ module.exports = {
     var connName = this.dictionary.update;
     var adapter = this.connections[connName]._adapter;
 
-    adapter.update(connName, this.collection, criteria, values, normalize.callback(function afterwards (err, updatedRecords) {
+    adapter.update(connName, this.collection, criteria, values, normalize.callback(function afterwards (err, updatedRecords, originalValues) {
       if (err) {
         if (typeof err === 'object') err.model = globalId;
         return cb(err);
       }
-      return cb(null, updatedRecords);
+      return cb(null, updatedRecords, originalValues);
     }));
   },
 

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -214,12 +214,17 @@ function updateRecords(valuesObject, cb) {
     });
 
     // prepare changeset by comparing updated values with originals
-    var changesets = transformedOriginals.map(function(value, index) {
-      Object.keys(value).forEach(function (key) {
-        if (value[key] == transformedValues[index][key]) { delete value[key]; }
+    var changesets = transformedOriginals.map(function(originalValue, index) {
+      var changeset = {};
+      transformedValues[index] && Object.keys(originalValue).forEach(function (key) {
+        var value = originalValue[key],
+          changedValue = transformedValues[index][key];
+
+        _.isBoolean(value) && (changedValue = Boolean(changedValue)); // extra type caset
+        !_.isEqual(value, changedValue) && (changeset[key] = value); // note the change
       });
 
-      return value;
+      return changeset;
     });
 
     // Update any nested associations and run afterUpdate lifecycle callbacks for each parent

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -194,7 +194,7 @@ function updateRecords(valuesObject, cb) {
 
 
   // Pass to adapter
-  self.adapter.update(valuesObject.criteria, valuesObject.values, function(err, values) {
+  self.adapter.update(valuesObject.criteria, valuesObject.values, function(err, values, originals) {
     if (err) {
       if (typeof err === 'object') { err.model = self._model.globalId; }
       return cb(err);
@@ -202,10 +202,24 @@ function updateRecords(valuesObject, cb) {
 
     // If values is not an array, return an array
     if(!Array.isArray(values)) values = [values];
+    if (!Array.isArray(originals)) {
+      originals = originals ? [originals] : [];
+    }
 
-    // Unserialize each value
-    var transformedValues = values.map(function(value) {
-      return self._transformer.unserialize(value);
+    // Unserialize each value and work on doing same for originals (ensures 1:1 index sync)
+    var transformedOriginals = [];
+    var transformedValues = values.map(function(value, index) {
+      transformedOriginals[index] = (self._cast.run(originals[index]) || {});
+      return value;
+    });
+
+    // prepare changeset by comparing updated values with originals
+    var changesets = transformedOriginals.map(function(value, index) {
+      Object.keys(value).forEach(function (key) {
+        if (value[key] == transformedValues[index][key]) { delete value[key]; }
+      });
+
+      return value;
     });
 
     // Update any nested associations and run afterUpdate lifecycle callbacks for each parent
@@ -221,7 +235,7 @@ function updateRecords(valuesObject, cb) {
           return new self._model(value);
         });
 
-        cb(null, models);
+        cb(null, models, changesets);
       });
     });
 


### PR DESCRIPTION
This change propagates the original values of a module as a third parameter of `.update` operations if (optionally) sent by the adapter.

Since `sails-mysql` makes a `SELECT` query before every update; it makes sense that the query results can be utilised to return the changeset when a model is updated. The third parameter of `.update` returns an array having objects that contain only the fields that have changed and that too with their original values.
